### PR TITLE
Add fixes for 2.6/Django 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Add to settings file:
         'arcutils',
     )
 
+In **Django 1.6 and worse** you must add this after Django apps have been loaded (for example, in a models.py file):
+
+    from arcutils.apps import ARCUtilsConfig
+    ARCUtilsConfig().ready()
+
+
 Optionally, add your LDAP connection information
 
     LDAP = {

--- a/arcutils/apps.py
+++ b/arcutils/apps.py
@@ -1,10 +1,17 @@
 from __future__ import absolute_import
 
+# Django verions 1.6 and worse don't have the "apps" package so we have to mock
+# it up when its not available
 try:
     from django.apps import AppConfig, apps
+    is_installed = apps.is_installed
 except ImportError:
     class AppConfig:
         pass
+
+    def is_installed(dotted_app_path):
+        from django.conf import settings
+        return dotted_app_path in settings.INSTALLED_APPS
 
 from . import DEFAULT_FEATURES
 
@@ -35,7 +42,7 @@ class ARCUtilsConfig(AppConfig):
 
         # hook up the session clearer
         CLEAR_EXPIRED_SESSIONS_AFTER_N_REQUESTS = getattr(settings, 'CLEAR_EXPIRED_SESSIONS_AFTER_N_REQUESTS', 100)
-        CLEAR_EXPIRED_SESSIONS_ENABLED = apps.is_installed('django.contrib.sessions') and CLEAR_EXPIRED_SESSIONS_AFTER_N_REQUESTS is not None
+        CLEAR_EXPIRED_SESSIONS_ENABLED = is_installed('django.contrib.sessions') and CLEAR_EXPIRED_SESSIONS_AFTER_N_REQUESTS is not None
         if ARCUTILS_FEATURES.get('clear_expired_sessions') and CLEAR_EXPIRED_SESSIONS_ENABLED:
             from .sessions import patch_sessions
 

--- a/arcutils/logging.py
+++ b/arcutils/logging.py
@@ -1,4 +1,4 @@
-import logging.config
+from __future__ import absolute_import
 import pkg_resources
 from copy import copy
 

--- a/arcutils/sessions.py
+++ b/arcutils/sessions.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from random import random
 import logging
 

--- a/runtests.py
+++ b/runtests.py
@@ -41,6 +41,12 @@ from django.test.utils import setup_test_environment
 setup()
 setup_test_environment()
 test_runner = DjangoTestSuiteRunner(verbosity=1)
+
+# Django 1.6 doesn't have the app loader, so you have to manually call ready()
+if django.VERSION[:2] < (1, 7):
+    from arcutils.apps import ARCUtilsConfig
+    ARCUtilsConfig().ready()
+
 failures = test_runner.run_tests(['arcutils', ])
 if failures:
     sys.exit(failures)


### PR DESCRIPTION
Now users on old Python/Django versions must add:

from arcutils.apps import ARCUtilsConfig
ARCUtilsConfig().ready()

after Django has loaded apps.