### PR TITLE
Fix an import problem for 2.6

### DIFF
--- a/arcutils/logging.py
+++ b/arcutils/logging.py
@@ -9,6 +9,7 @@ from django.conf import settings
 try:
     from logging import NullHandler
 except ImportError:
+    import logging
     class NullHandler(logging.Handler):
         def emit(self, record):
             pass

--- a/runtests.py
+++ b/runtests.py
@@ -27,7 +27,8 @@ settings.configure(
             "password": "",
             "search_dn": "ou=people,dc=pdx,dc=edu",
         }
-    }
+    },
+    LOGGING_CONFIG='arcutils.logging.basic',
 )
 
 if django.VERSION[:2] >= (1, 7):


### PR DESCRIPTION
By adding LOGGING_CONFIG='arcutils.logging.basic' to the test runner, we
can ensure the logging module at least can be imported without raising
something.