### PR TITLE
Update add_to_builtins import path for Django 1.8 compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.0] - 2015-03-12
+
+Made a few changes to support Django 1.8.
+
 ## [1.0.0] - 2015-03-12
+
 ### Added
 - Everything

--- a/arcutils/apps.py
+++ b/arcutils/apps.py
@@ -50,7 +50,7 @@ class ARCUtilsConfig(AppConfig):
 
         # add all the templatetag libraries we want available by default
         if ARCUTILS_FEATURES.get('templatetags'):
-            from django.template import add_to_builtins
+            from django.template.base import add_to_builtins
 
             add_to_builtins('django.contrib.staticfiles.templatetags.staticfiles')
             # add the arc template tags to the builtin tags, and the bootstrap tag

--- a/arcutils/sessions.py
+++ b/arcutils/sessions.py
@@ -2,8 +2,14 @@ from __future__ import absolute_import
 from random import random
 import logging
 
+try:
+    # Python >= 2.7
+    import importlib
+except ImportError:
+    # Python < 2.7; will be removed in Django 1.9
+    from django.utils import importlib
+
 from django.conf import settings
-from django.utils.importlib import import_module
 from django.core.exceptions import ImproperlyConfigured
 from django.core.signals import request_started
 
@@ -33,6 +39,6 @@ def patch_sessions(num_requests):
     if num_requests < 1:
         raise ImproperlyConfigured('The num_requests setting must be > 0')
 
-    clear_expired_sessions.engine = import_module(settings.SESSION_ENGINE)
+    clear_expired_sessions.engine = importlib.import_module(settings.SESSION_ENGINE)
     clear_expired_sessions.probability = 1.0 / num_requests
     request_started.connect(clear_expired_sessions)

--- a/runtests.py
+++ b/runtests.py
@@ -36,12 +36,12 @@ if django.VERSION[:2] >= (1, 7):
 else:
     setup = lambda: None
 
-from django.test.simple import DjangoTestSuiteRunner
+from django.test.runner import DiscoverRunner
 from django.test.utils import setup_test_environment
 
 setup()
 setup_test_environment()
-test_runner = DjangoTestSuiteRunner(verbosity=1)
+test_runner = DiscoverRunner(verbosity=1)
 
 # Django 1.6 doesn't have the app loader, so you have to manually call ready()
 if django.VERSION[:2] < (1, 7):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if sys.version_info[0] < 3:
 
 setup(
     name="django-arcutils",
-    version='1.0.0',
+    version='1.1.0',
     url='https://github.com/PSU-OIT-ARC/django-arcutils',
     author='Matt Johnson',
     author_email='mdj2@pdx.edu',


### PR DESCRIPTION
Importing from `django.template.base` is compatible with Django 1.6 to
1.8.